### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,15 +10,13 @@ jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.7]
     steps:
       - name: Checkout master
         uses: actions/checkout@v1
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        with:
+          python-version: '>=3.7'
         env:
           GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
-        # python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ scanalyser --help
 A full set of documentation is available at https://erik-white.github.io/ColonyScanalyser/
 
 ### Prerequisites
-ColonyScanalyser requires Python version 3.7, and the Pip package manager. Pip is included with Python version 3.4 and up.
+ColonyScanalyser requires Python version 3.7 or greater, and the Pip package manager. Pip is included with Python version 3.4 and up.
 
 The remaining Python package dependencies are automatically handled by Pip when installing the Colonyscanalyser package.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `plot_plate_images_animation` outputs animated gifs for each plate in two sizes
 - Full type hinting for all modules
 ### Changed
+- Extended compatibility to Python 3.8
 - Cached data is now not used by default
 - `use_saved` command line argument renamed to `use_cached_data`
 - Compressed serialised data filename changed to `cached_data`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 ## Python
-ColonyScanalyser requires Python version 3.7, and the Pip package manager. Pip is included with Python version 3.4 and up.
+ColonyScanalyser requires Python version 3.7 or greater, and the Pip package manager. Pip is included with Python version 3.4 and up.
 
 There are many [detailed guides on the web](https://docs.python-guide.org/starting/installation/) so I will only cover the most basic cases here.
 #### On Mac
@@ -16,7 +16,7 @@ Python may come bundled with your distribution, otherwise it will be available t
 sudo apt-get install python3.7
 ```
 #### On Windows
-Go to the [Python downloads site](https://www.python.org/downloads/windows/) and grab the latest Python 3.7 installer (currently 3.7.5). Run the installer once it has downloaded and follow the setup instructions.
+Go to the [Python downloads site](https://www.python.org/downloads/windows/) and grab the latest Python installer. Run the installer once it has downloaded and follow the setup instructions.
 
 ## ColonyScanalyser
 Use the Python package manager, Pip, to install the [ColonyScanalyser package](https://pypi.org/project/colonyscanalyser/):

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -3,13 +3,13 @@
 ## Install Python
 The most basic requirements for the package are simply Python with its package manager
 
-- Python 3.7
+- Python >= 3.7
 - Pip
 
 The [installation guide](installation.md) has more information on getting Python.
 
 ## Install ColonyScanalyser
-Once Python 3.7 is installed the Python package manager, Pip, can be used to install ColonyScanalyser. Open a command line window and install the package:
+Once Python is installed the Python package manager, Pip, can be used to install ColonyScanalyser. Open a command line window and install the package:
 ```
 pip3 install colonyscanalyser
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 -e .
 cycler==0.10.0
 decorator==4.4.1
-imageio==2.6.1
+imageio==2.8.0
 kiwisolver==1.1.0
-matplotlib==3.1.1
+matplotlib==3.1.3
 networkx==2.4
-numpy==1.17.3
-Pillow==6.2.1
-pyparsing==2.4.4
+numpy==1.18.1
+Pillow==7.0.0
+pyparsing==2.4.6
 python-dateutil==2.8.1
 PyWavelets==1.1.1
 scikit-image==0.16.2
-scipy==1.3.1
-six==1.13.0
-webcolors==1.10
+scipy==1.4.1
+six==1.14.0
+webcolors==1.11.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(*names, **kwargs):
 
 
 setup(
-    python_requires = ">=3.7, <3.8",
+    python_requires = ">=3.7",
     name = "colonyscanalyser",
     version = "0.4.0",
     description = "An image analysis tool for measuring microorganism colony growth",
@@ -30,7 +30,7 @@ setup(
     package_dir = {"": "src"},
     zip_safe = False,
     install_requires = [
-        "numpy",
+        "numpy >= 1.18",
         "matplotlib",
         "scikit-image >= 0.16",
         "webcolors"


### PR DESCRIPTION
Previous versions of Numpy were not compatible with Python 3.8. Numpy has now been updated and the package can now be used with Python >= 3.7