### PR TITLE
Correct DPI conversion factor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved flexibility when detecting date and time stamp information in file names
 ### Fixed
 - A rare error when opening images using skimage.io.imread
+- Corrected default DPI settings and conversion factor
 
 ## [0.3.4] - 2020-01-18
 ### Added

--- a/docs/image_specifications.md
+++ b/docs/image_specifications.md
@@ -4,7 +4,7 @@ ColonyScanalyser requires clear, high-resolution images from a static viewpoint.
 A program is needed to automatically set the scanners to take images at the desired set intervals.
 
 ### Scanners
-Scanners with a resolution of at least 2000 DPI are recommended, though greater image density will enable greater colony differentiation and improve first appearance detection.
+Scanners with a resolution of at least 300 DPI are recommended, though greater image density will enable greater colony differentiation and improve first appearance detection.
 ### Plates and holders
 To allow the colonies to easily be discerned in the image, a strongly contrasting background is needed. An easy technique is to paint the bottom of the plates black, or place them on black fabric.
 ### Image formats

--- a/src/colonyscanalyser/imaging.py
+++ b/src/colonyscanalyser/imaging.py
@@ -2,18 +2,19 @@ from typing import Optional, Union, Tuple, List
 from numpy import ndarray
 
 
-def mm_to_pixels(millimeters: float, dots_per_inch: float = 300, pixels_per_mm: Optional[float] = None) -> int:
+def mm_to_pixels(millimeters: float, dots_per_inch: float = 300, pixels_per_mm: Optional[float] = None) -> float:
     """
     Convert a measurement in millimetres to image pixels
 
     :param millimeters: the measurement to convert
     :param dots_per_inch: the conversion factor
     :param pixels_per_mm: optional conversion factor, instead of DPI
+    :returns: a value in pixels
     """
     if millimeters <= 0 or dots_per_inch <= 0 or (pixels_per_mm is not None and pixels_per_mm <= 0):
         raise ValueError("All supplied arguments must be positive values")
 
-    factor = dots_per_inch / 254
+    factor = dots_per_inch / 25.4
 
     if pixels_per_mm is not None:
         factor = pixels_per_mm

--- a/src/colonyscanalyser/main.py
+++ b/src/colonyscanalyser/main.py
@@ -122,7 +122,7 @@ def main():
     )
     parser.add_argument("path", type = str,
                         help = "Image files location", default = None)
-    parser.add_argument("-dpi", "--dots_per_inch", type = int, default = 2540,
+    parser.add_argument("-dpi", "--dots_per_inch", type = int, default = 300,
                         help = "The image DPI (dots per inch) setting")
     parser.add_argument("-mp", "--multiprocessing", type = strtobool, default = True,
                         help = "Enables use of more CPU cores, faster but more resource intensive")
@@ -148,7 +148,7 @@ def main():
     PLATE_EDGE_CUT = args.plate_edge_cut
     PLATE_LABELS = {plate_id: label for plate_id, label in enumerate(args.plate_labels, start = 1)}
     PLATE_LATTICE = tuple(args.plate_lattice)
-    PLATE_SIZE = imaging.mm_to_pixels(args.plate_size, dots_per_inch = args.dots_per_inch)
+    PLATE_SIZE = int(imaging.mm_to_pixels(args.plate_size, dots_per_inch = args.dots_per_inch))
     USE_CACHED = args.use_cached_data
     VERBOSE = args.verbose
     POOL_MAX = 1

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -95,18 +95,15 @@ class TestMMToPixels():
     def dpi(self, request):
         yield request.param
 
-    @pytest.fixture(params = [-1, 0, -25.4])
-    def arg_invalid(self, request):
-        yield request.param
-
     def test_dpi(self, measurements, dpi):
         result = mm_to_pixels(measurements, dpi)
-        assert result == int(measurements * (dpi / 254))
+        assert result == int(measurements * (dpi / 25.4))
 
     def test_ppmm(self, measurements, dpi):
         result = mm_to_pixels(measurements, dpi, pixels_per_mm = dpi)
         assert result == measurements * dpi
 
+    @pytest.mark.parametrize("arg_invalid", [-1, 0, -25.4])
     def test_arg_invalid(self, arg_invalid):
         with pytest.raises(ValueError):
             mm_to_pixels(arg_invalid, arg_invalid, pixels_per_mm = arg_invalid)


### PR DESCRIPTION
The current DPI to PPMM conversion factor is off by a factor of ten. The default value for the `dots_per_inch` command line argument is also incorrect by the same factor