### PR TITLE
Improve command line arguments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2020-06-02
+### Added
+- `--version` command line argument to display installed package version number
+### Changed
+- Improved the output from the `--help` command line argument to make it a little clearer
+
 ## [0.4.2] - 2020-05-18
 ### Added
 - Support for `bmp` image files

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.3] - 2020-06-02
 ### Added
 - `--version` command line argument to display installed package version number
+- `--image_formats` command line argument to display supported image formats
 ### Changed
 - Improved the output from the `--help` command line argument to make it a little clearer
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `--version` command line argument to display installed package version number
 - `--image_formats` command line argument to display supported image formats
+- Package configuration and now consolidated and loaded from a settings module
 ### Changed
 - Improved the output from the `--help` command line argument to make it a little clearer
 

--- a/docs/command_line_arguments.md
+++ b/docs/command_line_arguments.md
@@ -94,4 +94,10 @@ The level of information output to the command line. Default level is `1`, incre
 -v
 --verbose
 ```
+### Package version
+Displays the version number of the installed ColonyScanalyser package
+
+```
+--version
+```
 

--- a/docs/command_line_arguments.md
+++ b/docs/command_line_arguments.md
@@ -23,6 +23,12 @@ The image density your scanner uses, this can usually be found in your scanner s
 -dpi
 --dots_per_inch
 ```
+### Image formats
+Displays the currently supported image formats.
+
+```
+--image_formats
+```
 ### Multiprocessing
 This technique utilises all of the available processors that your computer has to analyse images in parallel. Since most computers now have at least 2 or 4 processors, this can greatly reduce the time needed to process a set of images.
 

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,19 @@ def read(*names, **kwargs):
         return fh.read()
 
 
+# Combine the readme and changelog to form the long_description
+long_description = "%s\n%s" % (
+        re.compile("^.. start-badges.*^.. end-badges", re.M | re.S).sub("", read("README.md")),
+        re.sub(":[a-z]+:`~?(.*?)`", r"``\1``", read("docs/CHANGELOG.md"))
+    )
+
+
 setup(
     python_requires = ">=3.7",
     name = "colonyscanalyser",
     version = "0.4.2",
     description = "An image analysis tool for measuring microorganism colony growth",
-    long_description = "%s\n%s" % (
-        re.compile("^.. start-badges.*^.. end-badges", re.M | re.S).sub("", read("README.md")),
-        re.sub(":[a-z]+:`~?(.*?)`", r"``\1``", read("docs/CHANGELOG.md"))
-    ),
+    long_description = long_description,
     long_description_content_type = "text/markdown",
     url = "https://github.com/Erik-White/ColonyScanalyser/",
     author = "Erik White",
@@ -33,7 +37,9 @@ setup(
         "numpy >= 1.18",
         "matplotlib",
         "scikit-image >= 0.17",
-        "webcolors"
+        "webcolors",
+        # Ensure metadata is available on Python <3.8
+        "importlib-metadata ~= 1.0 ; python_version < '3.8'",
     ],
     extras_require = {
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = "%s\n%s" % (
 setup(
     python_requires = ">=3.7",
     name = "colonyscanalyser",
-    version = "0.4.2",
+    version = "0.4.3",
     description = "An image analysis tool for measuring microorganism colony growth",
     long_description = long_description,
     long_description_content_type = "text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "scikit-image >= 0.17",
         "webcolors",
         # Ensure metadata is available on Python <3.8
-        "importlib-metadata ~= 1.0 ; python_version < '3.8'",
+        "importlib-metadata ~= 1.0 ; python_version < '3.8'"
     ],
     extras_require = {
         "dev": [

--- a/src/colonyscanalyser/config.py
+++ b/src/colonyscanalyser/config.py
@@ -1,0 +1,30 @@
+"""
+Package configuration
+"""
+
+# Images
+DOTS_PER_INCH = 300
+SUPPORTED_FORMATS = ["tif", "tiff", "png", "bmp"]
+
+# Plates
+PLATE_EDGE_CUT = 5
+PLATE_LATTICE = (3, 2)
+PLATE_SIZE = 90
+
+# Colonies
+COLONY_FIRST_AREA_MAX = 10
+COLONY_DISTANCE_MAX = 2
+COLONY_TIMEPOINTS_MIN = 5
+COLONY_TIMESTAMP_DIFF_MAX = 20
+COLONY_GROWTH_FACTOR_MIN = 4
+
+# Output
+CACHED_DATA_FILE_NAME = "cached_data"
+DATA_DIR = "data"
+OUTPUT_VERBOSE = 1
+OUTPUT_PLOTS = 1
+PLOTS_DIR = "data"
+
+# Runtime
+MULTIPROCESSING = True
+USE_CACHED_DATA = False

--- a/src/colonyscanalyser/main.py
+++ b/src/colonyscanalyser/main.py
@@ -24,6 +24,41 @@ from .plate import Plate, PlateCollection
 from .colony import Colony, timepoints_from_image, colonies_from_timepoints, timepoints_from_image
 
 
+def argparse_init(*args, **kwargs) -> argparse.ArgumentParser:
+    """
+    Initialise an ArgumentParser instance with the standard package arguments
+
+    :params args: positional arguments to pass to the ArgumentParser initialiser
+    :params kwargs: keyword arguments to pass to the ArgumentParser initialiser
+    """
+    parser = argparse.ArgumentParser(*args, **kwargs)
+    
+    parser.add_argument("path", type = str,
+                        help = "Image files location", default = None)
+    parser.add_argument("-dpi", "--dots_per_inch", type = int, default = 300,
+                        help = "The image DPI (dots per inch) setting", metavar = "N")
+    parser.add_argument("-mp", "--multiprocessing", type = strtobool, default = True,
+                        help = "Enables use of more CPU cores, faster but more resource intensive",  metavar = "BOOLEAN")
+    parser.add_argument("-p", "--plots", type = int, default = 1,
+                        help = "The detail level of plot images to store on disk", metavar = "N")
+    parser.add_argument("--plate_edge_cut", type = int, default = 5,
+                        help = "The exclusion area from the plate edge, as a percentage of the plate diameter", metavar = "N")
+    parser.add_argument("--plate_labels", type = str, nargs = "*", default = list(),
+                        help = "A list of labels to identify each plate. Plates are ordered from top left, in rows. Example usage: --plate_labels plate1 plate2",
+                        metavar = "LABEL")
+    parser.add_argument("--plate_lattice", type = int, nargs = 2, default = (3, 2),
+                        help = "The row and column co-ordinate layout of plates. Example usage: --plate_lattice 3 3",
+                        metavar = ("ROW", "COL"))
+    parser.add_argument("--plate_size", type = int, default = 90,
+                        help = "The plate diameter, in millimetres", metavar = "N")
+    parser.add_argument("--use_cached_data", type = strtobool, default = False,
+                        help = "Allow use of previously calculated data", metavar = "BOOLEAN")
+    parser.add_argument("-v", "--verbose", type = int, default = 1,
+                        help = "Information output level", metavar = "N")
+
+    return parser
+
+
 def segment_image(
     plate_image: ndarray,
     plate_mask: ndarray = None,
@@ -115,32 +150,13 @@ def image_file_to_timepoints(
 
 # flake8: noqa: C901
 def main():
-    parser = argparse.ArgumentParser(
+    parser = argparse_init(
         description = "An image analysis tool for measuring microorganism colony growth",
-        formatter_class = argparse.ArgumentDefaultsHelpFormatter
-    )
-    parser.add_argument("path", type = str,
-                        help = "Image files location", default = None)
-    parser.add_argument("-dpi", "--dots_per_inch", type = int, default = 300,
-                        help = "The image DPI (dots per inch) setting")
-    parser.add_argument("-mp", "--multiprocessing", type = strtobool, default = True,
-                        help = "Enables use of more CPU cores, faster but more resource intensive")
-    parser.add_argument("-p", "--plots", type = int, default = 1,
-                        help = "The detail level of plot images to store on disk")
-    parser.add_argument("--plate_edge_cut", type = int, default = 5,
-                        help = "The exclusion area from the plate edge, as a percentage of the plate diameter")
-    parser.add_argument("--plate_labels", type = str, nargs = "*", default = list(),
-                        help = "A list of labels to identify each plate. Plates are ordered from top left, in rows. Example usage: --plate_labels plate1 plate2")
-    parser.add_argument("--plate_lattice", type = int, nargs = 2, default = (3, 2),
-                        metavar = ("ROW", "COL"),
-                        help = "The row and column co-ordinate layout of plates. Example usage: --plate_lattice 3 3")
-    parser.add_argument("--plate_size", type = int, default = 90,
-                        help = "The plate diameter, in millimetres")
-    parser.add_argument("--use_cached_data", type = strtobool, default = False,
-                        help = "Allow use of previously calculated data")
-    parser.add_argument("-v", "--verbose", type = int, default = 1,
-                        help = "Information output level")
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter,
+        usage = "%(prog)s '/image/file/path/' [OPTIONS]"
+        )
 
+    # Retrieve and parse arguments
     args = parser.parse_args()
     BASE_PATH = args.path
     PLOTS = args.plots

--- a/src/colonyscanalyser/main.py
+++ b/src/colonyscanalyser/main.py
@@ -8,6 +8,11 @@ from distutils.util import strtobool
 from collections import defaultdict
 from multiprocessing import Pool, cpu_count
 from functools import partial
+try:
+    from importlib import metadata
+except ImportError:
+    # Running on pre-3.8 Python, use importlib-metadata package
+    import importlib_metadata as metadata
 
 # Third party modules
 from numpy import ndarray, diff
@@ -55,6 +60,8 @@ def argparse_init(*args, **kwargs) -> argparse.ArgumentParser:
                         help = "Allow use of previously calculated data", metavar = "BOOLEAN")
     parser.add_argument("-v", "--verbose", type = int, default = 1,
                         help = "Information output level", metavar = "N")
+    parser.add_argument("--version", action = "version", version = f"ColonyScanlayser {metadata.version('colonyscanalyser')}",
+                        help = "The package version number")
 
     return parser
 

--- a/src/colonyscanalyser/main.py
+++ b/src/colonyscanalyser/main.py
@@ -37,11 +37,15 @@ def argparse_init(*args, **kwargs) -> argparse.ArgumentParser:
     :params kwargs: keyword arguments to pass to the ArgumentParser initialiser
     """
     parser = argparse.ArgumentParser(*args, **kwargs)
+
+    supported_formats = ["tif", "tiff", "png", "bmp"]
     
     parser.add_argument("path", type = str,
                         help = "Image files location", default = None)
     parser.add_argument("-dpi", "--dots_per_inch", type = int, default = 300,
                         help = "The image DPI (dots per inch) setting", metavar = "N")
+    parser.add_argument("--image_formats", default = supported_formats, action = "version", version = str(supported_formats),
+                        help = "The supported image formats")
     parser.add_argument("-mp", "--multiprocessing", type = strtobool, default = True,
                         help = "Enables use of more CPU cores, faster but more resource intensive",  metavar = "BOOLEAN")
     parser.add_argument("-p", "--plots", type = int, default = 1,
@@ -166,6 +170,7 @@ def main():
     # Retrieve and parse arguments
     args = parser.parse_args()
     BASE_PATH = args.path
+    IMAGE_FORMATS = args.image_formats
     PLOTS = args.plots
     PLATE_LABELS = {plate_id: label for plate_id, label in enumerate(args.plate_labels, start = 1)}
     PLATE_LATTICE = tuple(args.plate_lattice)
@@ -218,8 +223,7 @@ def main():
 
     if not USE_CACHED or plates is None:
         # Find images in working directory
-        image_formats = ["tif", "tiff", "png", "bmp"]
-        image_paths = file_access.get_files_by_type(BASE_PATH, image_formats)
+        image_paths = file_access.get_files_by_type(BASE_PATH, IMAGE_FORMATS)
 
         # Store images as ImageFile objects
         # Timestamps are automatically read from filenames


### PR DESCRIPTION
- Add a `--version` argument, see #49 
- Improve clarity of output from `--help`, see #50
- Potentially move the list of supported image formats to a read-only command line argument