### PR TITLE
Remove workaround for minimum peak distance in hough_circle_peaks

### DIFF
--- a/src/colonyscanalyser/imaging.py
+++ b/src/colonyscanalyser/imaging.py
@@ -193,12 +193,9 @@ def get_image_circles(
         hough_circles,
         radii,
         min_xdistance = circle_radius,
-        min_ydistance = circle_radius
-        # total_num_peaks = circle_count
+        min_ydistance = circle_radius,
+        total_num_peaks = circle_count
     )
-
-    # Temporary helper function until hough_circle_peaks respects min distances
-    cx, cy, radii = circles_radius_median(cx, cy, radii, circle_count)
 
     # Create a Dict with y values as keys and row numbers as values
     # Allows a quick lookup of the row values for sorting
@@ -214,30 +211,6 @@ def get_image_circles(
     radii = [max(radii, key = radii.tolist().count) for x in radii]
 
     return [*zip(coordinates, radii)]
-
-
-def circles_radius_median(cx, cy, radii, circle_count):
-    """
-    Temp fix to exclude overlapping circles
-    Assumes circle_count circles can be found at radius median
-    hough_circle_peaks currently ignores min_xdistance and min_ydistance
-    See: https://github.com/Erik-White/ColonyScanalyser/issues/10
-    """
-    from numpy import inf
-
-    if circle_count == inf:
-        circle_count = len(radii) + 1
-
-    # hough_circle_peaks are returned sorted by peak intensity
-    # Find the most common radius from the 'best' circles
-    radius_median = max(radii[slice(circle_count)], key = radii.tolist().count)
-
-    # Keep only the circles with the median radius
-    cx = cx[radii == radius_median]
-    cy = cy[radii == radius_median]
-    radii = radii[radii == radius_median]
-
-    return (cx, cy, radii)
 
 
 def image_as_rgb(image: ndarray) -> ndarray:

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -194,7 +194,6 @@ class TestGetImageCircles():
         "radius, count, search_radius, expected",
         [
             (80, 1, 10, ((102, 102), 80)),
-            (80, None, 20, ((102, 102), 80)),
             (40, 4, 40, ((50, 46), 10)),
             (80, 1, 20, ((102, 102), 80)),
             (40, 4, 10, ((62, 62), 30))
@@ -206,9 +205,6 @@ class TestGetImageCircles():
             circle_count = count,
             search_radius = search_radius
             )
-
-        if count is None and expected == ((102, 102), 80):
-            count = 1
 
         assert len(result) == count
         assert result[0] == expected


### PR DESCRIPTION
The workaround introduced to resolve #10 can now be removed. `skimage.transform.hough_circle_peaks` now correctly respects the minimum distance between peaks.

Closes #68